### PR TITLE
bugfix - fixed favorites showing twice , users list update

### DIFF
--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -25,7 +25,7 @@ const NavBar = () => {
         textColor="primary"
       >
         <Tab label="Home" component={Link} to='/'/> 
-        <Tab label="Favorites" component={Link} to='/favorites' state={{name:"dan"}}/>
+        <Tab label="Favorites" component={Link} to='/favorites'/>
       </Tabs>
     </AppBar>
   );

--- a/src/components/UserList/UserList.js
+++ b/src/components/UserList/UserList.js
@@ -42,9 +42,6 @@ const UserList = ({ users, isLoading }) => {
       const newCheckedBoxes = [...checkedBoxes];
       currentIndex === -1 ? newCheckedBoxes.push(countryValue) : newCheckedBoxes.splice(currentIndex,1);
       setCheckedBoxes(newCheckedBoxes);
-      if(favoriteUsers){
-        users = [...users,...favoriteUsers];
-      }
       if(newCheckedBoxes.length == 0){
         setFilteredUsers(users);
         return;

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -7,6 +7,14 @@ import { UsersContext } from "hooks/UsersContext";
 
 const Home = () => {
   const {users,isLoading} = useContext(UsersContext);
+
+  const getUsersWithFavorites = ()=>{
+    const localStorageUsers = window.localStorage.getItem("favorites");
+    if(localStorageUsers)
+        return [...users,...JSON.parse(localStorageUsers)];
+    return users;
+  }
+
   return (
     <S.Home>
       <S.Content>
@@ -15,7 +23,7 @@ const Home = () => {
             PplFinder
           </Text>
         </S.Header>
-        <UserList users={users} isLoading={isLoading} />
+        <UserList users={getUsersWithFavorites()} isLoading={isLoading} />
       </S.Content>
     </S.Home>
   );


### PR DESCRIPTION
When refreshing the page and fetching new users list - the new one gets updated with stored favorite users from last session/refresh